### PR TITLE
woff2 font file to be imported from bootstrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
 			app.import(bootstrapPath + 'fonts/bootstrap/glyphicons-halflings-regular.svg', { destDir: '/fonts/bootstrap' });
 			app.import(bootstrapPath + 'fonts/bootstrap/glyphicons-halflings-regular.ttf', { destDir: '/fonts/bootstrap' });
 			app.import(bootstrapPath + 'fonts/bootstrap/glyphicons-halflings-regular.woff', { destDir: '/fonts/bootstrap' });
+			app.import(bootstrapPath + 'fonts/bootstrap/glyphicons-halflings-regular.woff2', { destDir: '/fonts/bootstrap' });
 			configMessage.push('glphicons enabled');
 		} else {
 			configMessage.push('glphicons disabled');


### PR DESCRIPTION
The woff2 file was not being imported, which would cause a 404 error.
