### PR TITLE
move broccoli-funnel to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-funnel": "^0.2.2",
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.1",
     "ember-cli-app-version": "0.3.3",
@@ -44,6 +43,7 @@
     "sass"
   ],
   "dependencies": {
+    "broccoli-funnel": "^0.2.2",
     "ember-cli-babel": "^4.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Moving broccoli-funnel to addon dependencies will install it as a dependency for the addon in the installation process.
