### PR TITLE
Add test for checking glyphicon files and add fix #55 with filtering content in funnel map around fastboot compatibility alteration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,7 @@ module.exports = {
   env: {
     browser: true
   },
-  rules: {
-  },
+  rules: {},
   overrides: [
     // node files
     {
@@ -24,7 +23,8 @@ module.exports = {
         'testem.js',
         'ember-cli-build.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'tests/dummy/config/**/*.js',
+        'node-tests/glyphicon-test.js'
       ],
       excludedFiles: [
         'app/**',

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = {
     });
   },
 
-  treeForVendor: function(vendorTree) {
+  treeForVendor(vendorTree) {
 
     let trees = [];
 
@@ -89,7 +89,7 @@ module.exports = {
       })
     );
 
-    return map(mergeTrees(trees), (content, relativePath) => {
+    return map(mergeTrees(trees), '**/*.js', (content, relativePath) => {
       if (relativePath.match(/\.js$/i)) {
         return `if (typeof FastBoot === 'undefined') { ${content} }`;
       }

--- a/node-tests/glyphicon-test.js
+++ b/node-tests/glyphicon-test.js
@@ -9,7 +9,7 @@ const importedGlyphiconFilePath = path.resolve(__dirname, '../dist/fonts/bootstr
 const originalGlyphiconBuffer = fs.readFileSync(originalGlyphiconFilePath);
 const importedGlyphiconBuffer = fs.readFileSync(importedGlyphiconFilePath);
 
-const isTheSame = originalGlyphiconBuffer === importedGlyphiconBuffer;
+const isTheSame = originalGlyphiconBuffer.equals(importedGlyphiconBuffer);
 if (isTheSame) {
   console.info('Glyphicon files are the same.') // eslint-disable-line no-console
 } else {

--- a/node-tests/glyphicon-test.js
+++ b/node-tests/glyphicon-test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const originalGlyphiconFilePath = path.resolve(__dirname, '../node_modules/bootstrap-sass/assets/fonts/bootstrap/glyphicons-halflings-regular.woff');
+const importedGlyphiconFilePath = path.resolve(__dirname, '../dist/fonts/bootstrap/glyphicons-halflings-regular.woff');
+
+const originalGlyphiconBuffer = fs.readFileSync(originalGlyphiconFilePath);
+const importedGlyphiconBuffer = fs.readFileSync(importedGlyphiconFilePath);
+
+const isTheSame = originalGlyphiconBuffer === importedGlyphiconBuffer;
+if (isTheSame) {
+  console.info('Glyphicon files are the same.') // eslint-disable-line no-console
+} else {
+  throw new Error('Glyphicon files are not the same.');
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "build": "ember build",
-    "lint:js":
-      "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
-    "test": "ember try:each"
+    "test:glyphicon": "ember build && node ./node-tests/glyphicon-test.js",
+    "test": "ember try:each && npm run test:glyphicon"
   },
   "repository": "https://github.com/lifegadget/ember-cli-bootstrap-sassy",
   "engines": {


### PR DESCRIPTION
* Add a Node.js test file which simply compare two files (glyphicon) content.
* Add filter to map function, so the broccoli-stew map doesn't modify the content of the font files.